### PR TITLE
Dao générique

### DIFF
--- a/backend/src/main/java/fr/univtln/m1infodid/projet_s2/backend/DAO/AnnotationDAO.java
+++ b/backend/src/main/java/fr/univtln/m1infodid/projet_s2/backend/DAO/AnnotationDAO.java
@@ -1,74 +1,16 @@
 package fr.univtln.m1infodid.projet_s2.backend.DAO;
+
 import fr.univtln.m1infodid.projet_s2.backend.model.Annotation;
 import fr.univtln.m1infodid.projet_s2.backend.model.Epigraphe;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityTransaction;
-import jakarta.persistence.Query;
-import jakarta.persistence.TypedQuery;
 
-import java.util.ArrayList;
-import java.util.List;
+public class AnnotationDAO extends GenericDAO<Annotation, Integer> {
 
-public class AnnotationDAO implements AutoCloseable{
-
-    private EntityManager entityManager;
     private AnnotationDAO ( EntityManager entityManager ) {
-        this.entityManager = entityManager;
+        super(Annotation.class, entityManager);
     }
 
     public static AnnotationDAO create ( EntityManager entityManager ) {
         return new AnnotationDAO(entityManager);
-    }
-
-
-    public Annotation findById(int id)
-    {
-        return entityManager.find(Annotation.class,id);
-    }
-
-    public List<Annotation> findAll()
-    {
-        TypedQuery<Annotation> query = entityManager.createQuery("SELECT M FROM Annotation as M ",Annotation.class);
-        return query.getResultList();
-    }
-
-
-    public Annotation persist(Annotation annotation) {
-        Epigraphe epigraphe = annotation.getEpigraphe();
-        try {
-            EpigrapheDAO epigrapheDAO = EpigrapheDAO.create(entityManager); //NOSONAR (L'entity manager sera fermé par la classe)
-            //l'entity manager sera fermé par la suite.
-            annotation.setEpigraphe(epigrapheDAO.getEpigraphe(epigraphe.getId()));
-        }
-        catch (Exception e)  {
-            return null;
-        }
-        EntityTransaction entityTransaction = entityManager.getTransaction();
-        entityTransaction.begin();
-        entityManager.persist(annotation);
-        entityTransaction.commit();
-        return annotation;
-    }
-
-    public void remove(int id)
-    {
-        EntityTransaction entityTransaction = entityManager.getTransaction();
-        entityTransaction.begin();
-        entityManager.remove(findById(id));
-        entityTransaction.commit();
-    }
-
-    public void remove(Annotation annotation)
-    {
-        EntityTransaction entityTransaction = entityManager.getTransaction();
-        entityTransaction.begin();
-        entityManager.remove(annotation);
-        entityTransaction.commit();
-    }
-
-    @Override
-    public void close() throws Exception {
-        entityManager.close();
-
     }
 }

--- a/backend/src/main/java/fr/univtln/m1infodid/projet_s2/backend/DAO/EpigrapheDAO.java
+++ b/backend/src/main/java/fr/univtln/m1infodid/projet_s2/backend/DAO/EpigrapheDAO.java
@@ -3,116 +3,51 @@ package fr.univtln.m1infodid.projet_s2.backend.DAO;
 import fr.univtln.m1infodid.projet_s2.backend.SI;
 import fr.univtln.m1infodid.projet_s2.backend.model.Epigraphe;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.TypedQuery;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Root;
-import lombok.extern.slf4j.Slf4j;
 
-import java.sql.SQLException;
 import java.time.LocalDate;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
 
-@Slf4j
-
-public class EpigrapheDAO implements AutoCloseable {
-
-    private EntityManager entityManager;
-
-
+public class EpigrapheDAO extends GenericDAO<Epigraphe, Integer> {
 
     private EpigrapheDAO ( EntityManager entityManager ) {
-        this.entityManager = entityManager;
+        super(Epigraphe.class, entityManager);
     }
 
     public static EpigrapheDAO create ( EntityManager entityManager ) {
-        return createEpigrapheDAO(entityManager);
-    }
-
-    private static EpigrapheDAO createEpigrapheDAO ( EntityManager entityManager ) {
         return new EpigrapheDAO(entityManager);
     }
 
     /**
-     * List of all the epigraphs.
+     * Récupère une instance de l'entité Epigraphe à partir de son identifiant.
      *
-     * @return list of the epigraphs
-     */
-    public List<Epigraphe> findAll () {
-        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-        CriteriaQuery<Epigraphe> cq = cb.createQuery(Epigraphe.class);
-        Root<Epigraphe> rootEntry = cq.from(Epigraphe.class);
-        CriteriaQuery<Epigraphe> all = cq.select(rootEntry);
-
-        TypedQuery<Epigraphe> allQuery = entityManager.createQuery(all);
-        return allQuery.getResultList();
-    }
-
-    /**
-     * Find an epigraph using its id.
+     * @param id L'identifiant de l'épigraphe à rechercher.
+     * @return L'épigraphe correspondant à l'identifiant spécifié, ou null s'il n'existe pas.
      *
-     * @return the epigraph
+     * @apiNote Cette méthode effectue une recherche de l'épigraphe en utilisant l'identifiant spécifié.
+     * Si l'épigraphe est trouvée, elle est mise à jour au-delà d'un délai de deux jours.
+     * Si la mise à jour est impossible, l'entité en base est retournée en l'état.
      */
-    public Epigraphe findById ( int id ) {
-        return entityManager.find(Epigraphe.class, id);
-    }
+    @Override
+    public Epigraphe findById ( Integer id ) {
+        Epigraphe epigraphe = getEntityManager().find(Epigraphe.class, id);
+        if (epigraphe == null) return null;
 
+        if (epigraphe.getFetchDate().isBefore(LocalDate.now().minusDays(2))) { // expiration du cache
+            getEntityManager().getTransaction().begin();
+            getEntityManager().detach(epigraphe); // Comme on va reconstruire l'objet, on le détache temporairement de JPA, qui pourrait les considérer égaux comme ils ont le même identifiant
 
-    /**
-     * Persist a new epigraph.
-     *
-     * @return the epigraph persisted
-     */
-    public Epigraphe persistID ( int id ) {
-        Epigraphe epi = new Epigraphe();
-        epi.setId(id);
-        entityManager.getTransaction().begin();
-        entityManager.persist(epi);
-        entityManager.getTransaction().commit();
-        log.info("Epigraph " + id + " was persisted.");
-        return epi;
-    }
-
-
-    public void persist(Epigraphe epigraphe){
-        entityManager.persist(epigraphe);
-    }
-
-    /**
-     * Remove an epigraph using its id.
-     */
-    public void remove ( int id ) throws SQLException {
-        entityManager.getTransaction().begin();
-        entityManager.remove(findById(id));
-        entityManager.getTransaction().commit();
-        log.info("Epigraph " + id + " was removed.");
-    }
-
-
-    public void remove(Epigraphe epigraphe) throws SQLException {
-        remove(epigraphe.getId());
-    }
-
-    public Epigraphe getEpigraphe(int id) throws Exception {
-        Epigraphe epigraphe = findById(id);
-
-        if(epigraphe !=null) {
-            LocalDate date = epigraphe.getFetchDate();
-
-            if (date.isBefore(LocalDate.now().plusDays(2)))
+            try {
+                epigraphe = SI.CreateEpigraphie(id);
+            } catch (Exception e) {
+                getEntityManager().merge(epigraphe);
+                getEntityManager().getTransaction().rollback();
                 return epigraphe;
-            remove(epigraphe);
+            }
+
+            getEntityManager().merge(epigraphe); // Rattachement et mise à jour
+            getEntityManager().getTransaction().commit();
         }
-        epigraphe = SI.CreateEpigraphie(id);
-        persist(epigraphe);
+
         return epigraphe;
     }
 
-
-    @Override
-    public void close () throws Exception {
-        entityManager.close();
-    }
 }

--- a/backend/src/main/java/fr/univtln/m1infodid/projet_s2/backend/DAO/FormulaireDAO.java
+++ b/backend/src/main/java/fr/univtln/m1infodid/projet_s2/backend/DAO/FormulaireDAO.java
@@ -1,111 +1,14 @@
 package fr.univtln.m1infodid.projet_s2.backend.DAO;
 
 import fr.univtln.m1infodid.projet_s2.backend.model.Formulaire;
-import jakarta.persistence.*;
-import lombok.extern.slf4j.Slf4j;
+import jakarta.persistence.EntityManager;
 
-import java.util.List;
-
-@Slf4j
-public class
-FormulaireDAO {
-    private static EntityManagerFactory emf = Persistence.createEntityManagerFactory("EpiPU");
-
-
-    /**
-     * créer un objet Formulaire dans BD en utilisant l'EntityManager
-     * @param formulaire l'objet Formulaire à persister
-     * @throws RuntimeException si la transaction ne marche pas
-     */
-    public static void createFormulaire(Formulaire formulaire) {
-        EntityManager em = emf.createEntityManager();
-        EntityTransaction tx = em.getTransaction();
-        try {
-            tx.begin();
-            em.persist(formulaire);
-            tx.commit();
-        } catch (Exception e) {
-            if (tx.isActive()) {
-                tx.rollback();
-            }
-            throw e;
-        } finally {
-            log.info("Persistance formulaire");
-            em.close();
-        }
+public class FormulaireDAO extends GenericDAO<Formulaire,Integer> {
+    private FormulaireDAO ( Class<Formulaire> entityClass, EntityManager entityManager ) {
+        super(entityClass, entityManager);
     }
 
-    /**
-    * update objet Formulaire existant dans la BD en utilisant l'EntityManager
-    * @param formulaire l'objet Formulaire à mettre à jour
-    */
-    public static void updateFormulaire(Formulaire formulaire) {
-        EntityManager em = emf.createEntityManager();
-        EntityTransaction tx = em.getTransaction();
-        try {
-            tx.begin();
-            em.merge(formulaire);
-            tx.commit();
-        } catch (Exception e) {
-            if (tx.isActive()) {
-                tx.rollback();
-            }
-            throw e;
-        } finally {
-            em.close();
-        }
-    }
-
-    /**
-     * Supprimer un objet Formulaire de la BD en utilisant l'EntityManager.
-     * @param id l'identifiant de l'objet Formulaire à supprimer
-     * */
-    public static void deleteFormulaire(int id) {
-        EntityManager em = emf.createEntityManager();
-        EntityTransaction tx = em.getTransaction();
-        try {
-            tx.begin();
-            Formulaire formulaire = em.find(Formulaire.class, id);
-            em.remove(formulaire);
-            tx.commit();
-        } catch (Exception e) {
-            if (tx.isActive()) {
-                tx.rollback();
-            }
-            throw e;
-        } finally {
-            em.close();
-        }
-    }
-
-
-    /**
-    * chercher et retourner un objet Formulaire à partir de son identifiant dans la BD en utilisant l'EntityManager.
-     * @param id l'identifiant de l'objet Formulaire à rechercher
-    */
-    public static Formulaire findByIdFormulaire(int id) {
-        EntityManager em = emf.createEntityManager();
-        try {
-            return em.find(Formulaire.class, id);
-        } finally {
-            em.close();
-        }
-    }
-
-
-
-    /**
-     * chercher et retourner une liste des objets Formulaire dans la BD en utilisant l'EntityManager.
-     *
-     * @return une liste d'objets Formulaire, ou une liste vide si la base de données est vide
-     */
-    public static List<Formulaire> findAllFormulaire() {
-        EntityManager em = emf.createEntityManager();
-        try {
-            Query query = em.createQuery("SELECT f FROM Formulaire f");
-            return query.getResultList();
-        } finally {
-            em.close();
-        }
+    public static FormulaireDAO create ( EntityManager entityManager ) {
+        return new FormulaireDAO(Formulaire.class, entityManager);
     }
 }

--- a/backend/src/main/java/fr/univtln/m1infodid/projet_s2/backend/DAO/GenericDAO.java
+++ b/backend/src/main/java/fr/univtln/m1infodid/projet_s2/backend/DAO/GenericDAO.java
@@ -1,0 +1,130 @@
+package fr.univtln.m1infodid.projet_s2.backend.DAO;
+import java.io.Serializable;
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.TypedQuery;
+
+/**
+ * Classe abstraite pour un DAO générique offrant des fonctionnalités de base pour les opérations CRUD (Create, Read, Update, Delete)
+ * sur une entité spécifiée.
+ *
+ * @param <T> Le type de l'entité associée au DAO.
+ * @param <PK> Le type de la clé primaire de l'entité associée.
+ *
+ * @apiNote Cette classe fournit des méthodes pour persister, rechercher, mettre à jour et supprimer des entités
+ * en utilisant le gestionnaire d'entités (EntityManager). La classe générique doit être étendue en spécifiant
+ * le type de l'entité associée et le type de sa clé primaire.
+ */
+public abstract class GenericDAO<T, PK extends Serializable>  implements AutoCloseable{
+
+    private final Class<T> entityClass;
+    private final EntityManager entityManager;
+
+    /**
+     * Constructeur de la classe GenericDAO.
+     *
+     * @param entityClass   Le type de l'entité associée au DAO.
+     * @param entityManager Le gestionnaire d'entités utilisé pour les opérations de persistance.
+     */
+    protected GenericDAO ( Class<T> entityClass, EntityManager entityManager ) {
+        this.entityClass = entityClass;
+        this.entityManager = entityManager;
+    }
+
+    /**
+     * Récupère le gestionnaire d'entités associé au DAO.
+     *
+     * @return Le gestionnaire d'entités utilisé pour les opérations de persistance.
+     */
+    public EntityManager getEntityManager () {
+        return entityManager;
+    }
+
+    /**
+     * Persiste une entité dans la base de données.
+     *
+     * @param entity L'entité a persister.
+     * @return L'entité persistée.
+     * @throws IllegalStateException Si une exception survient lors de la gestion de la transaction.
+     */
+    public T persist ( T entity ) throws IllegalStateException {
+        EntityTransaction transaction = entityManager.getTransaction();
+        transaction.begin();
+        entityManager.persist(entity);
+        transaction.commit();
+        return entity;
+    }
+
+    /**
+     * Recherche une entité dans la base de données en utilisant son identifiant.
+     *
+     * @param id L'identifiant de l'entité à rechercher.
+     * @return L'entité correspondant à l'identifiant spécifié, ou null si elle n'existe pas.
+     */
+    public T findById ( PK id ) {
+        return entityManager.find(entityClass, id);
+    }
+
+    /**
+     * Récupère toutes les entités de ce type dans la base de données.
+     *
+     * @return Une liste contenant toutes les entités de ce type.
+     */
+    public List<T> findAll () {
+        String query = "SELECT e FROM " + entityClass.getSimpleName() + " e";
+        TypedQuery<T> typedQuery = entityManager.createQuery(query, entityClass);
+        return typedQuery.getResultList();
+    }
+
+    @Override
+    public void close () throws Exception {
+        entityManager.close();
+    }
+
+    /**
+     * Met à jour une entité dans la base de données.
+     *
+     * @param entity L'entité à mettre à jour.
+     * @return L'entité mise à jour.
+     * @throws IllegalStateException Si une exception survient lors de la gestion de la transaction.
+     */
+    public T update ( T entity ) throws IllegalStateException {
+        EntityTransaction transaction = entityManager.getTransaction();
+        transaction.begin();
+        T updatedEntity  = entityManager.merge(entity);
+        transaction.commit();
+        return updatedEntity;
+    }
+
+    /**
+     * Supprime une entité de la base de données.
+     *
+     * @param entity L'entité à supprimer.
+     *
+     * @throws IllegalStateException Si une exception survient lors de la gestion de la transaction.
+     */
+    public void remove(T entity) throws IllegalStateException {
+        EntityTransaction transaction = entityManager.getTransaction();
+        transaction.begin();
+        entityManager.remove(entityManager.contains(entity) ? entity : entityManager.merge(entity));
+        transaction.commit();
+    }
+
+    /**
+     * Supprime une entité de la base de données en utilisant son identifiant.
+     *
+     * @param id L'identifiant de l'entité à supprimer.
+     *
+     * @throws IllegalStateException Si une exception survient lors de la gestion de la transaction.
+     */
+    public void removeById(PK id) throws IllegalStateException {
+        EntityTransaction transaction = entityManager.getTransaction();
+        transaction.begin();
+        T entity = entityManager.find(entityClass, id);
+        entityManager.remove(entity);
+        transaction.commit();
+    }
+}
+

--- a/backend/src/main/java/fr/univtln/m1infodid/projet_s2/backend/model/Annotation.java
+++ b/backend/src/main/java/fr/univtln/m1infodid/projet_s2/backend/model/Annotation.java
@@ -19,7 +19,7 @@ public class Annotation {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private int idAnnotation;
 
-    @ManyToOne
+    @ManyToOne(cascade=CascadeType.ALL)
     @JoinColumn(name = "idEpigraphe")
     private Epigraphe epigraphe;
     public Annotation () {

--- a/backend/src/test/java/fr/univtln/m1infodid/projet_s2/backend/DAO/AnnotationDAOTest.java
+++ b/backend/src/test/java/fr/univtln/m1infodid/projet_s2/backend/DAO/AnnotationDAOTest.java
@@ -1,6 +1,5 @@
 package fr.univtln.m1infodid.projet_s2.backend.DAO;
 import fr.univtln.m1infodid.projet_s2.backend.model.Annotation;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
@@ -8,11 +7,10 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-public class AnnotationDAOTest extends AnnotationDAOTestManager {
+ class AnnotationDAOTest extends AnnotationDAOTestManager {
 
     @Test
-    void findByIdTest() throws SQLException {
-        AnnotationDAO annotationDAO = AnnotationDAO.create(entityManager);
+    void findByIdTest() {
         Annotation annotation = Annotation.of(23);
         annotationDAO.persist(annotation);
         assertEquals(annotation,annotationDAO.findById(annotation.getIdAnnotation()));
@@ -20,25 +18,24 @@ public class AnnotationDAOTest extends AnnotationDAOTestManager {
     }
 
     @Test
-    void findAllTest() throws SQLException {
-        AnnotationDAO annotationDAO = AnnotationDAO.create(entityManager);
+    void findAllTest() {
         List<Annotation> annotationList;
         List<Annotation> annotationList1;
 
-        annotationList = entityManager.createQuery("SELECT A FROM Annotation as A", Annotation.class).getResultList();
+        annotationList = em.createQuery("SELECT A FROM Annotation as A", Annotation.class).getResultList();
         annotationList1 = annotationDAO.findAll();
         assertEquals(annotationList,annotationList1);
     }
 
     @Test
-    void persistAnnotationTest() throws SQLException {
+    void persistAnnotationTest() {
         Annotation annotation = annotationDAO.persist(Annotation.of(55));
         assertEquals(annotation,annotationDAO.findById(annotation.getIdAnnotation()));
         assertDoesNotThrow(() ->annotationDAO.remove(annotation));
     }
 
     @Test
-    void removeAnnotation() throws SQLException {
+    void removeAnnotation() {
         List<Annotation> size_before = annotationDAO.findAll();
         Annotation annotation = Annotation.of(33);
         annotationDAO.persist(annotation);

--- a/backend/src/test/java/fr/univtln/m1infodid/projet_s2/backend/DAO/EpigrapheDAOTest.java
+++ b/backend/src/test/java/fr/univtln/m1infodid/projet_s2/backend/DAO/EpigrapheDAOTest.java
@@ -1,7 +1,10 @@
 package fr.univtln.m1infodid.projet_s2.backend.DAO;
 
+import fr.univtln.m1infodid.projet_s2.backend.SI;
 import fr.univtln.m1infodid.projet_s2.backend.model.Epigraphe;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -24,41 +27,42 @@ final class EpigrapheDAOTest extends EpigrapheDAOTestManager {
 
     @Test
     void findIdTest () {
-        Epigraphe epigraphe = epigrapheDAO.persistID(-1);
+        Epigraphe epigraphe = epigrapheDAO.persist(Epigraphe.of(-1,"",new Date(),LocalDate.now(),"","",""));
         assertEquals(epigraphe, epigrapheDAO.findById(-1));
     }
 
     @Test
     void PersistIdTest () {
-        Epigraphe epigraphe = epigrapheDAO.persistID(-1);
+        Epigraphe epigraphe = epigrapheDAO.persist(Epigraphe.of(-1,"",new Date(),LocalDate.now(),"","",""));
         assertEquals(epigraphe, epigrapheDAO.findById(-1));
     }
 
     @Test
     void removeTestId () {
-        epigrapheDAO.persistID(-3);
-        final int size_before = epigrapheDAO.findAll().size();
-        assertDoesNotThrow(() -> epigrapheDAO.remove(-3));
-        assertEquals(size_before-1,epigrapheDAO.findAll().size());
+        final List<Epigraphe> size_before = epigrapheDAO.findAll();
+        epigrapheDAO.persist(Epigraphe.of(-3,"",new Date(),LocalDate.now(),"","",""));
+        assertDoesNotThrow(() -> epigrapheDAO.removeById(-3));
+        assertEquals(size_before, epigrapheDAO.findAll());
     }
 
     @Test
     void removeTestEpigraphe()
     {
+        List<Epigraphe> listBefore = epigrapheDAO.findAll();
         Epigraphe epigraphe = Epigraphe.of(-3,"Exemple",new Date(), LocalDate.now(),"Exemple",
                 "Exemple","Exemple");
         epigrapheDAO.persist(epigraphe);
-        List<Epigraphe> size_before = epigrapheDAO.findAll();
         assertDoesNotThrow(() -> epigrapheDAO.remove(epigraphe));
-        assertEquals(size_before,epigrapheDAO.findAll());
+        assertEquals(listBefore, epigrapheDAO.findAll());
     }
 
     @Test
-    void getEpigrapheTest() throws Exception {
-        Epigraphe epigraphe = epigrapheDAO.getEpigraphe(4);
-        epigraphe.setFetchDate(LocalDate.now().plusDays(3));
-        assertNotEquals(epigraphe,epigrapheDAO.getEpigraphe(4));
-        epigrapheDAO.remove(4);
+    void findByIdCacheTest() throws Exception {
+        Epigraphe epigraphe = SI.CreateEpigraphie(4);
+        epigraphe.setFetchDate(LocalDate.now().minusDays(3));
+        epigrapheDAO.persist(epigraphe);
+        assertNotEquals(epigrapheDAO.findById(4),epigraphe);
+        assertDoesNotThrow(()->epigrapheDAO.removeById(4));
     }
 
 

--- a/backend/src/test/java/fr/univtln/m1infodid/projet_s2/backend/DAO/EpigrapheDAOTestManager.java
+++ b/backend/src/test/java/fr/univtln/m1infodid/projet_s2/backend/DAO/EpigrapheDAOTestManager.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 public abstract class EpigrapheDAOTestManager {
-     protected EntityManagerFactory emf;
-     protected EntityManager em;
-     protected EpigrapheDAO epigrapheDAO;
+    protected EntityManagerFactory emf;
+    protected EntityManager em;
+    protected EpigrapheDAO epigrapheDAO;
 
     @BeforeEach
     public void setUp () {

--- a/backend/src/test/java/fr/univtln/m1infodid/projet_s2/backend/DAO/FormulaireDAOTest.java
+++ b/backend/src/test/java/fr/univtln/m1infodid/projet_s2/backend/DAO/FormulaireDAOTest.java
@@ -1,71 +1,61 @@
 package fr.univtln.m1infodid.projet_s2.backend.DAO;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.List;
+import fr.univtln.m1infodid.projet_s2.backend.model.Formulaire;
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
-import fr.univtln.m1infodid.projet_s2.backend.model.Formulaire;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 @Slf4j
 
-class FormulaireDAOTest {
+class FormulaireDAOTest extends FormulaireDAOTestManager {
 
-    private static EntityManagerFactory emf;
 
-    @BeforeAll
-    static void setUpBeforeClass() throws Exception {
-        emf = Persistence.createEntityManagerFactory("EpiPU");
-    }
-
-    @AfterAll
-    static void tearDownAfterClass() throws Exception {
-        emf.close();
-    }
 
     /**
      * Teste la méthode de création d'un formulaire dans la base de données.
      */
 
     @Test
-    void testCreateFormulaire() {
-        if (FormulaireDAO.findByIdFormulaire(101) != null)
-            FormulaireDAO.deleteFormulaire(101);
+    void testpersist() {
+        if (formulaireDAO.findById(101) != null)
+            formulaireDAO.removeById(101);
         Formulaire formulaire = Formulaire.of(101, "Nom", "Prenom", "email@test.com", "Affiliation", "Commentaire");
-        FormulaireDAO.createFormulaire(formulaire);
-        Formulaire formulaireRecupere = FormulaireDAO.findByIdFormulaire(101);
+        formulaireDAO.persist(formulaire);
+        Formulaire formulaireRecupere = formulaireDAO.findById(101);
         System.err.println(formulaireRecupere);
         System.err.println(formulaire);
-        assertTrue( formulaire.equals(formulaireRecupere) );
-        FormulaireDAO.deleteFormulaire(101);
+        assertEquals(formulaire, formulaireRecupere);
+        formulaireDAO.removeById(101);
     }
     /*
      * Teste la méthode de la mise a jour d'un formulaire dans la base de données.
      */
     @Test
-    void testUpdateFormulaire() {
+    void testupdate() {
         Formulaire formulaire = Formulaire.of(101, "Nom2", "Prenom2", "email2@test.com", "Affiliation2", "Commentaire2");
-        FormulaireDAO.createFormulaire(formulaire);
+        formulaireDAO.persist(formulaire);
         formulaire.setNom("Nouveau nom");
-        FormulaireDAO.updateFormulaire(formulaire);
-        Formulaire formulaireRecupere = FormulaireDAO.findByIdFormulaire(101);
+        formulaireDAO.update(formulaire);
+        Formulaire formulaireRecupere = formulaireDAO.findById(101);
         assertEquals("Nouveau nom", formulaireRecupere.getNom());
-        FormulaireDAO.deleteFormulaire(101);
+        formulaireDAO.removeById(101);
     }
 
     /*
      * Teste la méthode de la suppression  d'un formulaire dans la base de données.
      */
     @Test
-    void testDeleteFormulaire() {
+    void testremoveById() {
         Formulaire formulaire = Formulaire.of(101, "Nom3", "Prenom3", "email3@test.com", "Affiliation3", "Commentaire3");
-        FormulaireDAO.createFormulaire(formulaire);
-        FormulaireDAO.deleteFormulaire(101);
-        Formulaire formulaireRecupere = FormulaireDAO.findByIdFormulaire(3);
+        formulaireDAO.persist(formulaire);
+        formulaireDAO.removeById(101);
+        Formulaire formulaireRecupere = formulaireDAO.findById(3);
         assertNull(formulaireRecupere);
     }
 
@@ -73,12 +63,12 @@ class FormulaireDAOTest {
     Teste la méthode de recherche d'un formulaire dans la base de données en utilisant son ID.
     */
     @Test
-    void testFindByIdFormulaire() {
+    void testfindById() {
         Formulaire formulaire = Formulaire.of( 101,"Nom4", "Prenom4", "email4@test.com", "Affiliation4", "Commentaire4");
-        FormulaireDAO.createFormulaire(formulaire);
-        Formulaire formulaireRecupere = FormulaireDAO.findByIdFormulaire(101);
+        formulaireDAO.persist(formulaire);
+        Formulaire formulaireRecupere = formulaireDAO.findById(101);
         assertEquals(formulaire, formulaireRecupere);
-        FormulaireDAO.deleteFormulaire(101);
+        formulaireDAO.removeById(101);
 
     }
 
@@ -89,13 +79,13 @@ class FormulaireDAOTest {
     void testFindAllFormulaire() {
         Formulaire formulaire1 = Formulaire.of(100, "Nom5", "Prenom5", "email5@test.com", "Affiliation5", "Commentaire5");
         Formulaire formulaire2 = Formulaire.of(101, "Nom6", "Prenom6", "email6@test.com", "Affiliation6", "Commentaire6");
-        FormulaireDAO.createFormulaire(formulaire1);
-        FormulaireDAO.createFormulaire(formulaire2);
-        List<Formulaire> formulaireListe = FormulaireDAO.findAllFormulaire();
+        formulaireDAO.persist(formulaire1);
+        formulaireDAO.persist(formulaire2);
+        List<Formulaire> formulaireListe = formulaireDAO.findAll();
         assertTrue(formulaireListe.contains(formulaire1));
         assertTrue(formulaireListe.contains(formulaire2));
-        FormulaireDAO.deleteFormulaire(100);
-        FormulaireDAO.deleteFormulaire(101);
+        formulaireDAO.removeById(100);
+        formulaireDAO.removeById(101);
 
     }
 

--- a/backend/src/test/java/fr/univtln/m1infodid/projet_s2/backend/DAO/FormulaireDAOTestManager.java
+++ b/backend/src/test/java/fr/univtln/m1infodid/projet_s2/backend/DAO/FormulaireDAOTestManager.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
-public abstract class AnnotationDAOTestManager {
+public abstract class FormulaireDAOTestManager {
     private static EntityManagerFactory emf;
-    protected static EntityManager em;
-    protected static AnnotationDAO annotationDAO;
+    private static EntityManager em;
+    protected static FormulaireDAO formulaireDAO;
     @BeforeAll
     static void setUpBeforeClass() {
         emf = Persistence.createEntityManagerFactory("EpiPU");
@@ -19,7 +19,7 @@ public abstract class AnnotationDAOTestManager {
     @BeforeEach
     void setup() {
         em = emf.createEntityManager();
-        annotationDAO = AnnotationDAO.create(em);
+        formulaireDAO = FormulaireDAO.create(em);
     }
     @AfterEach
     void end(){

--- a/backend/src/test/java/fr/univtln/m1infodid/projet_s2/backend/server/ApiTest.java
+++ b/backend/src/test/java/fr/univtln/m1infodid/projet_s2/backend/server/ApiTest.java
@@ -1,6 +1,10 @@
 package fr.univtln.m1infodid.projet_s2.backend.server;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
 import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -86,16 +90,20 @@ class ApiTest {
     @Test
     void shouldNotReturnAcorretFormulaire(){
         String inputJson = "{\n" +
-                "  \"idFormulaire\":\"1\",\n" +
-                "  \"nomFormulaire\":\"A\",\n" +
-                "  \"prenomFormulaire\":\"B\",\n" +
-                "  \"emailFormulaire\":\"test@gmail.com\",\n" +
-                "  \"affiliationFormulaire\":\"prof\"\n" +
-                "  \"commentaireAffiliation\":\"none\"" +
-                "}";
+                "  \"idFormulaire\":\"1\",\n" + "  \"nomFormulaire\":\"A\",\n" + "  \"prenomFormulaire\":\"B\",\n" + "  \"emailFormulaire\":\"test@gmail.com\",\n" + "  \"affiliationFormulaire\":\"prof\"\n" + "  \"commentaireAffiliation\":\"none\"" + "}";
         Api api = new Api();
         Response r = api.receiveFormulaire(inputJson);
         assertNotEquals(r.toString(), Response.ok().build().toString());
     }
 
+    @AfterEach
+    void TearDown () {
+        try (EntityManagerFactory entityManagerFactory = Persistence.createEntityManagerFactory("EpiPU");
+             EntityManager entityManager = entityManagerFactory.createEntityManager()) {
+            entityManager.getTransaction().begin();
+            entityManager.createNativeQuery("DELETE from formulaire where id_formulaire = 1;").executeUpdate();
+            entityManager.getTransaction().commit();
+        }
+
+    }
 }


### PR DESCRIPTION
Ce commit réécriture le code de la persistance avec transition vers un DAO générique. Tous les tests unitaires ont été adaptés.

Ce commit corrige également la logique de cache dans les annotations et les épigraphes.

