### PR TITLE
Prise en charge de l'authentification par l'API

### DIFF
--- a/backend/src/main/java/fr/univtln/m1infodid/projet_s2/backend/model/Verification.java
+++ b/backend/src/main/java/fr/univtln/m1infodid/projet_s2/backend/model/Verification.java
@@ -1,4 +1,4 @@
-package fr.univtln.m1infodid.projet_s2.frontend.server;
+package fr.univtln.m1infodid.projet_s2.backend.model;
 
 import java.util.regex.Pattern;
 
@@ -13,7 +13,7 @@ public class Verification {
     // Norme HTML5 du W3C  (cf https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address)
 
 
-    private Verification() {
+    private Verification () {
         throw new IllegalStateException("Cette classe ne devrait pas etre instancier");
     }
 

--- a/backend/src/main/java/fr/univtln/m1infodid/projet_s2/backend/server/Api.java
+++ b/backend/src/main/java/fr/univtln/m1infodid/projet_s2/backend/server/Api.java
@@ -1,23 +1,25 @@
 package fr.univtln.m1infodid.projet_s2.backend.server;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import fr.univtln.m1infodid.projet_s2.backend.DAO.FormulaireDAO;
-import fr.univtln.m1infodid.projet_s2.backend.model.Epigraphe;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import fr.univtln.m1infodid.projet_s2.backend.DAO.FormulaireDAO;
 import fr.univtln.m1infodid.projet_s2.backend.SI;
 import fr.univtln.m1infodid.projet_s2.backend.model.Annotation;
+import fr.univtln.m1infodid.projet_s2.backend.model.Epigraphe;
 import fr.univtln.m1infodid.projet_s2.backend.model.Formulaire;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Persistence;
+import fr.univtln.m1infodid.projet_s2.backend.model.Verification;
 import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.*;
+import java.util.Base64;
+import java.util.Optional;
 
 
 /**
@@ -134,4 +136,24 @@ public class Api {
 		return Response.notModified().build();
 	}
 
+	@Path("user/login")
+	@POST
+	@Consumes(MediaType.APPLICATION_JSON)
+	public Response receiveLogin ( @Context HttpHeaders headers ) {
+		String authorizationHeader = headers.getHeaderString(HttpHeaders.AUTHORIZATION);
+
+		if (authorizationHeader != null && authorizationHeader.startsWith("Basic ")) {
+			String base64Credentials = authorizationHeader.substring("Basic ".length());
+			String decodedCredentials = new String(Base64.getDecoder().decode(base64Credentials));
+			String[] usernamePassword = decodedCredentials.split(":", 2);
+
+			if (usernamePassword.length == 2 && !usernamePassword[1].isEmpty() && Verification.isInputAvalideEmail(usernamePassword[0])) {
+				String username = usernamePassword[0];
+				String password = usernamePassword[1];
+				log.info("Username : " + username + ", password : " + password);
+				return Response.ok().entity("Bienvenue " + username + " !").build();
+			}
+		} // No Authorization header or invalid format
+		return Response.status(Response.Status.UNAUTHORIZED).entity("Missing or invalid Authorization header").build();
+	}
 }

--- a/frontend/src/main/java/fr/univtln/m1infodid/projet_s2/frontend/Facade.java
+++ b/frontend/src/main/java/fr/univtln/m1infodid/projet_s2/frontend/Facade.java
@@ -1,14 +1,8 @@
 package fr.univtln.m1infodid.projet_s2.frontend;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import fr.univtln.m1infodid.projet_s2.frontend.javafx.SceneType;
 import fr.univtln.m1infodid.projet_s2.frontend.javafx.controller.FormulaireController;
 import fr.univtln.m1infodid.projet_s2.frontend.javafx.controller.MenuController;
@@ -19,24 +13,30 @@ import fr.univtln.m1infodid.projet_s2.frontend.server.Api;
 import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Facade principale du Frontend pour faciliter la communication entre Api et UI
  */
 public class Facade {
 
     private Facade () {
-        throw new IllegalStateException("Ne dois pas être instancié");
+        throw new IllegalStateException("Ne doit pas être instancié");
     }
-    
+
     private static Stage primaryStage;
 
-    private static SceneData<MenuController> menuData; //scène et controller du menu 
+    private static SceneData<MenuController> menuData; //scène et controller du menu
     private static SceneData<PageVisualisationController> visuEpiData; //scène et controller de la page visualisation
     private static SceneData<FormulaireController> formData;
 
-    public static void initStage(Stage primaryStage) { 
+    public static void initStage(Stage primaryStage) {
         if (Facade.primaryStage != null) return;
-        Facade.primaryStage = primaryStage; 
+        Facade.primaryStage = primaryStage;
     }
 
     public static boolean isMenuStageShown() { return primaryStage.getScene() == menuData.scene(); }
@@ -87,6 +87,11 @@ public class Facade {
         jsonForm.put("commentaireFormulaire",commentaire);
 
         Api.postFormulaire(jsonForm.toString());
+    }
+
+    public static void sendLoginAndPasseword ( String email, String passeword ) {
+
+        Api.postLogin(Base64.getEncoder().encodeToString((email + ":" + passeword).getBytes()));
     }
 
     public static void showScene(SceneType type) {

--- a/frontend/src/main/java/fr/univtln/m1infodid/projet_s2/frontend/javafx/controller/MenuController.java
+++ b/frontend/src/main/java/fr/univtln/m1infodid/projet_s2/frontend/javafx/controller/MenuController.java
@@ -8,6 +8,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.Parent;
 import javafx.scene.control.Label;
+import javafx.scene.control.PasswordField;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.*;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +27,7 @@ public class MenuController implements Initializable {
     @FXML
     private Label connecter;
     @FXML
-    private TextField inputPassword;
+    private PasswordField inputPassword;
     @FXML
     private AnchorPane anchorPane;
     @FXML
@@ -78,11 +79,11 @@ public class MenuController implements Initializable {
     public void connexionButtonPressed() {
         String mail = inputMail.getText();
         // String password = inputPassword.getText();Pour l'authentification
-        testMailCorrectness(mail);
+        if(testMailCorrectness(mail)) {
+            Facade.sendLoginAndPasseword(inputMail.getText(),inputPassword.getText());
+            }
         inputMail.setText("");
         inputPassword.setText("");
-
-        //authentification
     }
 
 
@@ -91,12 +92,12 @@ public class MenuController implements Initializable {
      *
      * @param email
      */
-    public void testMailCorrectness(String email) {
+    public boolean testMailCorrectness(String email) {
         if (!Verification.isInputAvalideEmail(email)) {
             alert.setDisable(false);
             alertController.showNotValidEmail();
             inputMail.getStyleClass().add("wrongMail");
-            return;
+            return false;
             // inputMail.setStyle("-fx-control-inner-background: #2F3855; -fx-text-inner-color: #f4c4c4; -fx-prompt-text-fill: grey; -fx-text-box-border: #803C3C; -fx-background-radius: 10 10 0 0;");
         }
         
@@ -105,6 +106,7 @@ public class MenuController implements Initializable {
             inputMail.getStyleClass().addAll("text-field", "text-input");
         }
         // inputMail.setStyle("-fx-control-inner-background: #2F3855; -fx-text-inner-color: #f4c4c4; -fx-prompt-text-fill: grey; -fx-text-box-border: #2F3855; -fx-background-radius: 10 10 0 0;");
+        return true;
     }
 
     public AlertController getAlertController() { return alertController; }

--- a/frontend/src/main/java/fr/univtln/m1infodid/projet_s2/frontend/server/Api.java
+++ b/frontend/src/main/java/fr/univtln/m1infodid/projet_s2/frontend/server/Api.java
@@ -1,18 +1,17 @@
 package fr.univtln.m1infodid.projet_s2.frontend.server;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.ws.rs.Path;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Api REST pour les epigraphe
@@ -114,6 +113,7 @@ public class Api {
                 }
                 formJson = response.readEntity(String.class);
             } catch (Exception e) {
+                log.error(e.toString());
                 log.warn("Erreur lors de l'envoi des données");
             }
         } catch (Exception e) {
@@ -121,7 +121,30 @@ public class Api {
         }
         return formJson;
     }
+
+
+    public static String postLogin ( String encodedCredentials ) {
+        String loginJson="";
+        try (Client client = ClientBuilder.newClient();
+             Response response = client.target(URI_API_BACKEND + "user/login")
+                     .request(MediaType.APPLICATION_JSON).header("Authorization", "Basic " + encodedCredentials)
+                     .post(Entity.json(""))) {
+
+            if (response.getStatus() != 200) {
+                throw new IllegalStateException("La requête a échoué : code d'erreur HTTP " + response.getStatus());
+            }
+            loginJson = response.readEntity(String.class);
+            log.info(loginJson);
+        } catch (Exception e) {
+            log.warn("Erreur lors de l'envoi des données");
+            log.error(e.toString());
+            log.warn("Erreur lors de la lecture de la chaîne JSON");
+        }
+        return loginJson;
+    }
+
 }
+
 
 
 

--- a/frontend/src/main/resources/fr.univtln.m1infodid.projet_s2.frontend.javafx.view/menu.fxml
+++ b/frontend/src/main/resources/fr.univtln.m1infodid.projet_s2.frontend.javafx.view/menu.fxml
@@ -17,6 +17,7 @@
 <?import javafx.scene.shape.Circle?>
 <?import javafx.scene.text.Font?>
 
+<?import javafx.scene.control.PasswordField?>
 <AnchorPane fx:id="anchorPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" style="-fx-background-color: #24293d;" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="fr.univtln.m1infodid.projet_s2.frontend.javafx.controller.MenuController">
 	<children>
 		<BorderPane fx:id="mainPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
@@ -153,11 +154,11 @@
 																<Insets bottom="10.0" left="15.0" top="10.0" />
 															</padding>
 														</TextField>
-														<TextField fx:id="inputPassword" promptText="Mot de passe">
+														<PasswordField fx:id="inputPassword" promptText="Mot de passe">
 															<padding>
 																<Insets bottom="10.0" left="15.0" top="10.0" />
 															</padding>
-														</TextField>
+														</PasswordField>
       														<Button fx:id="buttonConection" mnemonicParsing="false" onAction="#connexionButtonPressed" prefWidth="250.0" text="Connexion">
                                              <padding>
                                                 <Insets bottom="10.0" top="10.0" />

--- a/frontend/src/test/java/fr/univtln/m1infodid/projet_s2/frontend/frontend/ApiTest.java
+++ b/frontend/src/test/java/fr/univtln/m1infodid/projet_s2/frontend/frontend/ApiTest.java
@@ -3,19 +3,22 @@ package fr.univtln.m1infodid.projet_s2.frontend.frontend;
 import fr.univtln.m1infodid.projet_s2.frontend.server.Api;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
+import java.util.Base64;
 import java.util.List;
 
-public class ApiTest {
+import static org.junit.jupiter.api.Assertions.*;
+
+  class ApiTest {
 
     /*
     Cette méthode teste la méthode sendRequestOf() de la classe Api en envoyant une requête avec un ID valide.
     *Elle vérifie que le résultat n'est pas nul.
      */
     @Test
-    public void testSendRequestOf() {
+      void testSendRequestOf() {
         Integer id = 1;
         List<String> result = Api.sendRequestOf(id);
         Assertions.assertNotNull(result);
@@ -26,7 +29,7 @@ public class ApiTest {
     *Elle vérifie que le résultat est une chaîne vide.
      */
     @Test
-    public void testSendRequestOfWithInvalidId() {
+     void testSendRequestOfWithInvalidId() {
         Integer id = -1;
         List<String> result = Api.sendRequestOf(id);
         assertEquals(0, result.size());
@@ -37,7 +40,7 @@ public class ApiTest {
     *Elle vérifie que le résultat n'est pas nul.
      */
     @Test
-    public void testPostAnnotations() {
+     void testPostAnnotations() {
         String annotationsJson = "{\"annotations\": []}";
         String result = Api.postAnnotations(annotationsJson);
         Assertions.assertNotNull(result);
@@ -48,7 +51,7 @@ public class ApiTest {
     *Elle vérifie que le résultat est une chaîne vide.
      */
     @Test
-    public void testPostAnnotationsWithInvalidJson() {
+     void testPostAnnotationsWithInvalidJson() {
         String annotationsJson = "{\"annotations\" []}";
         String result = Api.postAnnotations(annotationsJson);
         assertEquals("", result);
@@ -59,7 +62,7 @@ public class ApiTest {
      *Elle vérifie que le résultat est une chaîne vide.
      */
     @Test
-    public void testPostAnnotationsWithNullJson() {
+     void testPostAnnotationsWithNullJson() {
         String annotationsJson = null;
         String result = Api.postAnnotations(annotationsJson);
         assertEquals("", result);
@@ -69,7 +72,7 @@ public class ApiTest {
     *Test réussi - vérification de la valeur de retour
      */
     @Test
-    public void testSendRequestOfSuccess() {
+     void testSendRequestOfSuccess() {
         Integer id = 42;
         List<String> expectedResult = List.of("étude Philippe Leveau", 
                                                 "Thu Jul 12 00:00:00 GMT 2018", 
@@ -89,9 +92,35 @@ public class ApiTest {
     *Test en cas d'échec de la requête (404 Not Found)
      */
     @Test
-    public void testSendRequestOfRequestFailure() {
+     void testSendRequestOfRequestFailure() {
         Integer id = 100000;
         List<String> actualResult = Api.sendRequestOf(id);
         assertEquals(0, actualResult.size());
     }
+
+    @ParameterizedTest
+    @CsvSource({
+            "Tom@gmail.com:/ ,{[39?",
+            "Tom@gmail.com:/: ,{[39?",
+            "Tom@gmail.com:Seraph"
+    })
+    void testPostLoginOK(String credentials) {
+       String loginCredential = Base64.getEncoder().encodeToString((credentials).getBytes());
+       String response = Api.postLogin(loginCredential);
+       assertFalse(response.isEmpty());
+       assertEquals("Bienvenue Tom@gmail.com !", response);
+    }
+
+    @Test
+     void testpostEmptyPassword(){
+        String loginCredential = Base64.getEncoder().encodeToString( "Tom@gmail.com:".getBytes());
+        String reponse = Api.postLogin(loginCredential);
+        assertTrue(reponse.isEmpty());
+    }
+
+
+
+
+
+
 }


### PR DESCRIPTION
## Pull Request pour l'issue #60 
Cette PR met en place l'API qui permettra de gérer l'authentification des utilisateurs. 

Elle remplace aussi le champ de mot de passe de l'application par un `PasswordField` et met à jour la regex de vérification du mail pour l'aligner sur celle du standard HTML5


- [X] Implantation
- [x] Test

fixes #60 